### PR TITLE
Configuracion para tipografia

### DIFF
--- a/src/app/providers.jsx
+++ b/src/app/providers.jsx
@@ -2,11 +2,12 @@
 
 import { CacheProvider } from '@chakra-ui/next-js';
 import { ChakraProvider } from '@chakra-ui/react';
+import theme from '../theme';
 
 export function Providers({ children }) {
   return (
     <CacheProvider>
-      <ChakraProvider>{children}</ChakraProvider>
+      <ChakraProvider theme={theme}>{children}</ChakraProvider>
     </CacheProvider>
   );
 }

--- a/src/theme/foundations/typography.js
+++ b/src/theme/foundations/typography.js
@@ -1,0 +1,15 @@
+import { Montserrat } from 'next/font/google';
+
+const montserrat = Montserrat({
+  subsets: ['latin'],
+  display: 'swap',
+});
+
+const typography = {
+  fonts: {
+    body: montserrat.style.fontFamily,
+    heading: montserrat.style.fontFamily,
+  },
+};
+
+export default typography;

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,0 +1,8 @@
+import { extendTheme } from '@chakra-ui/react';
+import typography from './foundations/typography';
+
+const overrides = {
+  ...typography,
+};
+
+export default extendTheme(overrides);


### PR DESCRIPTION
## Description

Se agrega custom theme de Chakra y se sobreescribe la tipografia default.

### How to verify this PR

1. Todos los elementos de texto del app deben usar Montserrat como tipografia

Tipografia default
<img width="1342" alt="image" src="https://github.com/cetav-ddw/lalibertad-cetav/assets/598867/c1ca8404-d12f-4a3e-8b65-e1c031b3c988">

Con Montserrat
<img width="1338" alt="image" src="https://github.com/cetav-ddw/lalibertad-cetav/assets/598867/81d2ce32-0d19-4e4a-9b57-da258689c913">

