### PR TITLE
responsive cursos libres

### DIFF
--- a/src/app/components/CourseList.jsx
+++ b/src/app/components/CourseList.jsx
@@ -7,6 +7,7 @@ import {
   LinkOverlay,
   List,
   ListItem,
+  Grid,
 } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import SectionHeading from '@/app/components/SectionHeading';
@@ -17,13 +18,9 @@ export const CourseList = ({ cursos, showDescription, title }) => {
       {cursos?.length > 0 ? (
         <Box mb="16">
           {title && <SectionHeading title={title} />}
-          <Box
-            display="flex"
-            flexWrap="wrap"
-            alignItems="center"
-            gap="4"
-            justifyContent="center"
-            pos="relative"
+          <Grid
+            templateColumns={["repeat(1, 1fr)", "repeat(2, 1fr)", "repeat(3, 1fr)"]}
+            gap={4}
           >
             {cursos.map(({ id, imgSrc, title, descripcion, url, details }) => {
               const Component = url ? LinkOverlay : Box;
@@ -33,14 +30,13 @@ export const CourseList = ({ cursos, showDescription, title }) => {
                 <LinkBox
                   bg="rgba(225, 231, 248, 1)"
                   key={id}
-                  maxWidth="22%"
                   borderRadius="lg"
                   _hover={{ opacity: url ? 0.8 : 1 }}
                 >
                   <Box position="relative">
                     <Image
                       w="100%"
-                      h="240"
+                      h={["215", "240"]}
                       src={imgSrc}
                       alt=""
                       borderRadius="lg"
@@ -69,10 +65,8 @@ export const CourseList = ({ cursos, showDescription, title }) => {
                     </Text>
                   ) : null}
 
-                  {/* Esta seccion se puede mover a un componente aparte,
-                  falta hacer render de cada detalle */}
                   {showDescription && details?.length > 0 ? (
-                    <List px="2" py="4" fontSize="sm">
+                    <List px="2" py="4" fontSize={["xs", "sm"]}>
                       {details.map((detail) => {
                         return <ListItem key={detail}>{detail}</ListItem>;
                       })}
@@ -81,7 +75,7 @@ export const CourseList = ({ cursos, showDescription, title }) => {
                 </LinkBox>
               );
             })}
-          </Box>
+          </Grid>
         </Box>
       ) : null}
     </>

--- a/src/app/components/PageHeading.jsx
+++ b/src/app/components/PageHeading.jsx
@@ -2,9 +2,9 @@ import { Flex, Box, Heading, Text } from '@chakra-ui/react';
 
 const PHeading = ({ title, titleColor, text, imgSrc }) => {
   return (
-    <Flex mb="24" justifyContent="space-between">
-      <Box maxWidth="48%">
-        <Heading as="h1" fontSize="4xl" mb="8">
+    <Flex flexWrap="wrap" justifyContent="space-between">
+      <Box flex={["100%", "100%", "48%"]} mb={["4", "4", "24"]}>
+        <Heading as="h1" fontSize={["3xl", "4xl"]} mb="8">
           <Text as="span" display="block">
             {title}
           </Text>
@@ -14,7 +14,7 @@ const PHeading = ({ title, titleColor, text, imgSrc }) => {
         </Heading>
 
         {text ? (
-          <Text fontSize="lg" color="#444444">
+          <Text fontSize={["md" ,"lg"]} color="#444444">
             {text}
           </Text>
         ) : null}
@@ -26,11 +26,12 @@ const PHeading = ({ title, titleColor, text, imgSrc }) => {
           backgroundRepeat="no-repeat"
           backgroundPosition="center"
           backgroundSize="cover"
-          width="100%"
-          maxWidth="48%"
+          width={["100%", "100%", "48%"]}
+          maxWidth="100%"
           height="auto"
-          paddingTop="350px"
+          paddingTop={["50%", "350px"]}
           borderRadius="lg"
+          marginBottom="24px"
         />
       ) : null}
     </Flex>


### PR DESCRIPTION
responsive cursos libres

## Description

Se realizo el responsive de la pagina "Cursos Libres", menos el header y footer, ya que esos componentes fueron asignados a otros companeros

![Screenshot 2023-11-09 211934](https://github.com/cetav-ddw/lalibertad-cetav/assets/106450277/f8b13e34-d0a8-4cb8-bde7-4cef3c528877)

### How to verify this PR

<!-- List steps to verify your changes, add screenshots or videos as needed -->

1. Revisar el responsive de la pagina "Cursos Libres"

