### PR TITLE
direccionamiento a correo

### DIFF
--- a/src/app/components/InscriptionBanner.jsx
+++ b/src/app/components/InscriptionBanner.jsx
@@ -26,11 +26,13 @@ export default function InscriptionBanner() {
         >
           <Box>
             <Heading fontSize="3xl" mb="45px">
-              ¿Deseas ser parte de la comunidad CETAV e inscribirte con nosotros?
+              ¿Deseas ser parte de la comunidad CETAV e inscribirte con
+              nosotros?
             </Heading>
             <Text fontSize="2xl">
               {/* TODO PONER LINK AL CORREO  */}
               <Link
+                href="mailto:admision.cetav@lalibertadcr.org"
                 display="inline-block"
                 textDecoration="underline"
                 _hover={{


### PR DESCRIPTION
## Descripción

Se agregó un enlace `mailto:` al texto "¡Escríbínos ahora!" en el componente `InscriptionBanner`.

### Verificación

1. Ir a la página que tenga `InscriptionBanner`.
2. Click en "¡Escríbínos ahora!".
3. Comprobar que el correo predeterminado se abre con `admision.cetav@lalibertadcr.org`.
